### PR TITLE
[test] 대규모_동시성_쿠폰_발급_테스트 테스트 성공

### DIFF
--- a/src/main/java/com/sparta/able/config/redis/RedisConfig.java
+++ b/src/main/java/com/sparta/able/config/redis/RedisConfig.java
@@ -29,9 +29,9 @@ public class RedisConfig {
         configuration.setPort(6379); // Redis 기본 포트
         configuration.setPassword(password); // 비밀번호 설정
 
-        return new LettuceConnectionFactory(configuration); // Redis 호스트와 포트 설정
+        //return new LettuceConnectionFactory(configuration); // Redis 호스트와 포트 설정
 
-        //return new LettuceConnectionFactory("localhost", 6379); // Redis 호스트와 포트 설정
+        return new LettuceConnectionFactory("localhost", 6379); // Redis 호스트와 포트 설정
     }
 
     // RedisTemplate 설정

--- a/src/main/java/com/sparta/able/repository/CouponRepository.java
+++ b/src/main/java/com/sparta/able/repository/CouponRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 @Repository
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
     Optional<Coupon> findByName(String testCoupon);
-    Optional<Coupon> findFirstByName(String name);  // 첫 번째 쿠폰만 반환
+    Optional<Coupon> findFirstByName(String name);// 첫 번째 쿠폰만 반환
+    Optional<Coupon> findById(Long CouponId);
 }

--- a/src/test/java/com/sparta/able/CouponServiceConcurrencyTest.java
+++ b/src/test/java/com/sparta/able/CouponServiceConcurrencyTest.java
@@ -33,11 +33,11 @@ public class CouponServiceConcurrencyTest {
     @BeforeEach
     void setup() {
         // 테스트용 쿠폰 데이터 생성 (1000개 쿠폰 생성)
-        CouponRequestDto requestDto = new CouponRequestDto("Test Coupon2", 1000); // 쿠폰 수량 1000개
+        CouponRequestDto requestDto = new CouponRequestDto("Test Coupon6", 1000); // 쿠폰 수량 1000개
         couponService.createCoupon(requestDto);
 
         // 첫 번째 쿠폰만 가져오기
-        Coupon coupon = couponRepository.findFirstByName("Test Coupon2")
+        Coupon coupon = couponRepository.findFirstByName("Test Coupon6")
                 .orElseThrow(() -> new IllegalStateException("Test coupon not found."));
 
         this.couponId = coupon.getId();
@@ -48,7 +48,7 @@ public class CouponServiceConcurrencyTest {
 
     @Test
     void 대규모_동시성_쿠폰_발급_테스트() throws InterruptedException {
-        int threadCount = 500; // 5000명의 동시 요청
+        int threadCount = 500; // 500명의 동시 요청
         int amount = 1; // 한 번에 감소시킬 쿠폰 수량
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);

--- a/src/test/java/com/sparta/able/CouponServiceConcurrencyTest.java
+++ b/src/test/java/com/sparta/able/CouponServiceConcurrencyTest.java
@@ -1,9 +1,7 @@
 package com.sparta.able;
 
 import com.sparta.able.dto.coupon.req.CouponRequestDto;
-import com.sparta.able.dto.coupon.res.CouponResponseDto;
 import com.sparta.able.entity.Coupon;
-import com.sparta.able.enums.CouponStatus;
 import com.sparta.able.repository.CouponRepository;
 import com.sparta.able.service.CouponService;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,13 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
 public class CouponServiceConcurrencyTest {
@@ -36,22 +32,25 @@ public class CouponServiceConcurrencyTest {
 
     @BeforeEach
     void setup() {
-        // 테스트용 쿠폰 데이터 생성
-        CouponRequestDto requestDto = new CouponRequestDto("Test Coupon", 10); // 쿠폰 수량 10개
-        CouponResponseDto responseDto = couponService.createCoupon(requestDto);
+        // 테스트용 쿠폰 데이터 생성 (1000개 쿠폰 생성)
+        CouponRequestDto requestDto = new CouponRequestDto("Test Coupon2", 1000); // 쿠폰 수량 1000개
+        couponService.createCoupon(requestDto);
 
         // 첫 번째 쿠폰만 가져오기
-        Coupon coupon = couponRepository.findFirstByName("Test Coupon")
+        Coupon coupon = couponRepository.findFirstByName("Test Coupon2")
                 .orElseThrow(() -> new IllegalStateException("Test coupon not found."));
 
         this.couponId = coupon.getId();
+
+        // Redis 재고 초기화
+        couponService.initializeCouponStock(couponId, 1000);
     }
 
-
     @Test
-    void 동시성_테스트()  {
+    void 대규모_동시성_쿠폰_발급_테스트() throws InterruptedException {
+        int threadCount = 500; // 5000명의 동시 요청
         int amount = 1; // 한 번에 감소시킬 쿠폰 수량
-        int threadCount = 50; // 동시에 요청하는 사용자 수
+
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CyclicBarrier barrier = new CyclicBarrier(threadCount);
 
@@ -59,7 +58,7 @@ public class CouponServiceConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     barrier.await(); // 모든 스레드가 준비될 때까지 대기
-                    couponService.decrease(couponId, amount);
+                    couponService.decreaseWithLock(Coupon.class, couponId, amount); // Redis Lock 활용한 감소
                 } catch (Exception e) {
                     System.out.println("Error: " + e.getMessage());
                 }
@@ -68,41 +67,18 @@ public class CouponServiceConcurrencyTest {
 
         executorService.shutdown();
         while (!executorService.isTerminated()) {
-            // 대기
+            Thread.sleep(100); // 모든 스레드가 종료될 때까지 대기
         }
 
-        // 쿠폰 데이터 검증
+        // 최종 쿠폰 재고 확인
         Coupon coupon = couponRepository.findById(couponId).orElseThrow();
-        System.out.println("Remaining Coupons: " + coupon.getCount());
-        assertThat(coupon.getCount()).isGreaterThanOrEqualTo(0); // 음수 여부 확인
+        System.out.println("최종 남은 쿠폰 수량: " + coupon.getCount());
+        assertThat(coupon.getCount()).isGreaterThanOrEqualTo(0);
+
+        // Redis 재고 확인
+        String remainingStockString = (String) redisTemplate.opsForValue().get("coupon_stock:" + couponId);
+        Integer remainingStock = (remainingStockString != null) ? Integer.valueOf(remainingStockString) : 0;
+        System.out.println("Redis에 저장된 최종 재고: " + remainingStock);
+        assertThat(remainingStock).isEqualTo(coupon.getCount());
     }
-
-    @Test
-    void 쿠폰_발급_테스트() {
-        Long couponId = 3L;
-        int amount = 1; // 한 번에 감소시킬 쿠폰 수량
-        // 쿠폰 재고 초기화
-        couponService.initializeCouponStock(couponId, 10);
-
-        // Redis에서 초기 재고 값 확인
-        String initialStockString = (String) redisTemplate.opsForValue().get("coupon_stock:" + couponId);
-        Integer initialStock = (initialStockString != null) ? Integer.valueOf(initialStockString) : 0;
-        System.out.println("초기 재고: " + initialStock);
-        assertThat(initialStock).isEqualTo(10);  // 초기 재고가 10인지 확인
-
-        // 쿠폰 발급 테스트
-        for (int i = 0; i < 15; i++) {
-            try {
-                couponService.decrease(couponId, amount);
-                // 쿠폰 발급 성공 시 출력
-                String remainingStockString = (String) redisTemplate.opsForValue().get("coupon_stock:" + couponId);
-                Integer remainingStock = (remainingStockString != null) ? Integer.valueOf(remainingStockString) : 0;
-                System.out.println(" 남은 재고: " + remainingStock);
-            } catch (Exception e) {
-                // 발급 실패 시 출력
-                System.out.println("Error: " + e.getMessage());
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
- 문제점 : decreaseWithLock() 메서드에서는 redisLockRepository.lock()을 통해 락을 획득한 뒤 decrease()를 호출하여 데이터베이스의 재고만 감소시키고 있습니다.
하지만 Redis 재고(coupon_stock:{couponId})를 업데이트하는 로직이 포함되지 않아 Redis와 데이터베이스 간 재고가 동기화되지 않는 문제가 발생합니다.
- 해결책 : decrease() 메서드에서 Redis의 재고 값을 함께 감소시키도록 로직을 추가했습니다.